### PR TITLE
Fix Component Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ To upload the CSS styles, you can move the **leux.min.css** from the **node_modu
 
 ### To-do
 
-- Finish select documentation
-- Add husky and lint-staged
+- Table Component
 - improve tests and test coverage
 
 ## Next steps:

--- a/docs/src/pages/Badge/BadgeAttributes.tsx
+++ b/docs/src/pages/Badge/BadgeAttributes.tsx
@@ -6,24 +6,24 @@ import { Badge } from "../../../../src";
 
 const BadgeImportPreview = () => <LeHighlighter code={`import { Badge, BadgeProps } from "leux";`} language="tsx" />;
 
-const BadgeTypePreview = () => (
+const BadgeVariantPreview = () => (
 	<>
 		<div className="le-preview">
-			<Badge type="dashed" variant="primary">
+			<Badge variant="dashed" theme="primary">
 				Dashed
 			</Badge>
-			<Badge type="outlined" variant="primary">
+			<Badge variant="outlined" theme="primary">
 				Outlined
 			</Badge>
-			<Badge type="ghost" variant="danger">
+			<Badge variant="ghost" theme="danger">
 				Ghost
 			</Badge>
 		</div>
 		<LeHighlighter
 			code={`const Component = () => (
 	<>
-		<Badge type="dashed">Dashed</Badge>
-		<Badge type="ghost">Ghost</Badge>)
+		<Badge variant="dashed" theme="primary">Dashed</Badge>
+		<Badge variant="ghost" theme="primary">Ghost</Badge>)
 	</>
 );`}
 			language="tsx"
@@ -31,25 +31,25 @@ const BadgeTypePreview = () => (
 	</>
 );
 
-const BadgeVariantPreview = () => (
+const BadgeThemePreview = () => (
 	<>
 		<div className="le-preview">
-			<Badge variant="primary">Primary</Badge>
-			<Badge variant="secondary">Secondary</Badge>
-			<Badge variant="success">Success</Badge>
-			<Badge variant="danger">Danger</Badge>
-			<Badge variant="warning">Warning</Badge>
-			<Badge variant="default">Default</Badge>
+			<Badge theme="primary">Primary</Badge>
+			<Badge theme="secondary">Secondary</Badge>
+			<Badge theme="success">Success</Badge>
+			<Badge theme="danger">Danger</Badge>
+			<Badge theme="warning">Warning</Badge>
+			<Badge theme="default">Default</Badge>
 		</div>
 		<LeHighlighter
 			code={`const Component = () => (
 	<>
-		<Badge variant="primary">Primary</Badge>
-		<Badge variant="secondary">Secondary</Badge>
-		<Badge variant="success">Success</Badge>
-		<Badge variant="danger">Danger</Badge>
-		<Badge variant="warning">Warning</Badge>
-		<Badge variant="default">Default</Badge>
+		<Badge theme="primary">Primary</Badge>
+		<Badge theme="secondary">Secondary</Badge>
+		<Badge theme="success">Success</Badge>
+		<Badge theme="danger">Danger</Badge>
+		<Badge theme="warning">Warning</Badge>
+		<Badge theme="default">Default</Badge>
 	</>
 );`}
 			language="tsx"
@@ -86,7 +86,11 @@ const BadgeSizePreview = () => (
 const BadgeCustomPreview = () => (
 	<>
 		<div className="le-preview">
-			<Badge customClass="le-color-bg--primary" type="dashed" customStyles={{ color: "purple", borderColor: "purple" }}>
+			<Badge
+				customClass="le-color-bg--primary"
+				variant="dashed"
+				customStyles={{ color: "purple", borderColor: "purple" }}
+			>
 				Custom Badge
 			</Badge>
 		</div>
@@ -107,7 +111,7 @@ const BadgeCustomPreview = () => (
 
 badgeAttr["LeSourceButton"] = LeSourceButton;
 badgeAttr["BadgeImportPreview"] = BadgeImportPreview;
-badgeAttr["BadgeTypePreview"] = BadgeTypePreview;
+badgeAttr["BadgeThemePreview"] = BadgeThemePreview;
 badgeAttr["BadgeVariantPreview"] = BadgeVariantPreview;
 badgeAttr["BadgeSizePreview"] = BadgeSizePreview;
 badgeAttr["BadgeCustomPreview"] = BadgeCustomPreview;

--- a/docs/src/pages/Badge/badge.md
+++ b/docs/src/pages/Badge/badge.md
@@ -20,24 +20,24 @@ Badge Component is used to display relevant informations like tags, versions, fo
 
 <br/>
 
-#### Types
+#### Variant
 
-Use the `type` prop to change the badge style type.
-
-<div>
-<BadgeTypePreview>
-</BadgeTypePreview>
-</div>
-
-<br/>
-
-#### Variants
-
-Use the `variant` prop to change the badge color theme.
+Use the `variant` prop to change the badge style type.
 
 <div>
 <BadgeVariantPreview>
 </BadgeVariantPreview>
+</div>
+
+<br/>
+
+#### Theme
+
+Use the `theme` prop to change the badge color theme.
+
+<div>
+<BadgeThemePreview>
+</BadgeThemePreview>
 </div>
 
 <br/>

--- a/docs/src/pages/Button/ButtonAttributes.tsx
+++ b/docs/src/pages/Button/ButtonAttributes.tsx
@@ -5,42 +5,42 @@ import { attributes as buttonAttr } from "./button.md";
 
 const ButtonImportPreview = () => <LeHighlighter language="tsx" code={`import { Button, ButtonProps } from "leux";`} />;
 
-const ButtonVariantPreview = () => (
+const ButtonThemePreview = () => (
 	<>
 		<div className="le-preview">
-			<Button variant="primary">Primary</Button>
-			<Button variant="secondary">Secondary</Button>
-			<Button variant="success">Success</Button>
-			<Button variant="warning">Warning</Button>
-			<Button variant="danger">Danger</Button>
-			<Button variant="default">Default</Button>
+			<Button theme="primary">Primary</Button>
+			<Button theme="secondary">Secondary</Button>
+			<Button theme="success">Success</Button>
+			<Button theme="warning">Warning</Button>
+			<Button theme="danger">Danger</Button>
+			<Button theme="default">Default</Button>
 		</div>
 		<LeHighlighter
 			language="tsx"
 			code={`const Component = () => (
 	<>
-		<Button variant="primary">Primary</Button>
-		<Button variant="secondary">Secondary</Button>
-		<Button variant="success">Success</Button>
-		<Button variant="warning">Warning</Button>
-		<Button variant="danger">Danger</Button>
-		<Button variant="default">Default</Button>
+		<Button theme="primary">Primary</Button>
+		<Button theme="secondary">Secondary</Button>
+		<Button theme="success">Success</Button>
+		<Button theme="warning">Warning</Button>
+		<Button theme="danger">Danger</Button>
+		<Button theme="default">Default</Button>
 	</>
 );`}
 		/>
 	</>
 );
 
-const ButtonTypePreview = () => (
+const ButtonVariantPreview = () => (
 	<>
 		<div className="le-preview">
-			<Button variant="primary" type="filled">
+			<Button theme="primary" variant="filled">
 				Filled
 			</Button>
-			<Button variant="success" type="outlined">
+			<Button theme="success" variant="outlined">
 				Outlined
 			</Button>
-			<Button variant="danger" type="ghost">
+			<Button theme="danger" variant="ghost">
 				Ghost
 			</Button>
 		</div>
@@ -48,13 +48,13 @@ const ButtonTypePreview = () => (
 			language="tsx"
 			code={`const Component = () => (
 	<>
-		<Button variant="primary" type="filled">
+		<Button theme="primary" variant="filled">
 			Filled
 		</Button>
-		<Button variant="success" type="outlined">
+		<Button theme="success" variant="outlined">
 			Outlined
 		</Button>
-		<Button variant="danger" type="ghost">
+		<Button theme="danger" variant="ghost">
 			Ghost
 		</Button>
 	</>
@@ -66,11 +66,11 @@ const ButtonTypePreview = () => (
 const ButtonSizePreview = () => (
 	<>
 		<div className="le-preview">
-			<Button variant="default" size="small">
+			<Button theme="default" size="small">
 				Small
 			</Button>
-			<Button variant="default">Medium</Button>
-			<Button variant="default" size="large">
+			<Button theme="default">Medium</Button>
+			<Button theme="default" size="large">
 				Large
 			</Button>
 		</div>
@@ -78,9 +78,9 @@ const ButtonSizePreview = () => (
 			language="tsx"
 			code={`const Component = () => (
 	<>
-		<Button variant="default" size="small">Small</Button>
-		<Button variant="default">Medium</Button>
-		<Button variant="default" size="large">Large</Button>
+		<Button theme="default" size="small">Small</Button>
+		<Button theme="default" size="medium">Medium</Button>
+		<Button theme="default" size="large">Large</Button>
 	</>
 );`}
 		/>
@@ -97,10 +97,10 @@ const ButtonStatePreview = () => {
 	return (
 		<>
 			<div className="le-preview">
-				<Button variant={disabled ? "primary" : "danger"} onClick={handleOnClick}>
+				<Button theme={disabled ? "primary" : "danger"} onClick={handleOnClick}>
 					{disabled ? "on" : "off"}
 				</Button>
-				<Button variant="default" state={{ disabled }}>
+				<Button theme="default" state={{ disabled }}>
 					{disabled ? "disabled" : "enabled"}
 				</Button>
 			</div>
@@ -138,7 +138,7 @@ const ButtonActionPreview = () => {
 	return (
 		<>
 			<div className="le-preview">
-				<Button onClick={handleOnClick} variant="success">
+				<Button onClick={handleOnClick} theme="success">
 					Alert
 				</Button>
 			</div>
@@ -148,7 +148,7 @@ const ButtonActionPreview = () => {
 	const handleOnClick = () => alert("Hello World!");
 
 	return (
-		<Button onClick={handleOnClick} variant="success">Alert</Button>
+		<Button onClick={handleOnClick} theme="success">Alert</Button>
 	);
 };`}
 			/>
@@ -157,8 +157,8 @@ const ButtonActionPreview = () => {
 };
 
 buttonAttr["ButtonImportPreview"] = ButtonImportPreview;
-buttonAttr["ButtonTypePreview"] = ButtonTypePreview;
 buttonAttr["ButtonVariantPreview"] = ButtonVariantPreview;
+buttonAttr["ButtonThemePreview"] = ButtonThemePreview;
 buttonAttr["ButtonSizePreview"] = ButtonSizePreview;
 buttonAttr["ButtonStatePreview"] = ButtonStatePreview;
 buttonAttr["ButtonActionPreview"] = ButtonActionPreview;

--- a/docs/src/pages/Button/button.md
+++ b/docs/src/pages/Button/button.md
@@ -17,19 +17,19 @@ Button component is used to fire events. Commom used on forms, modals, panels an
 
 <br/>
 
-#### Types
+#### Variant
 
-Use the `type` prop to change the button type.
+Use the `variant` prop to change the button style.
 
-<div><ButtonTypePreview></ButtonTypePreview></div>
+<div><ButtonVariantPreview></ButtonVariantPreview></div>
 
 <br/>
 
-#### Variants
+#### Theme
 
-Use the `variant` prop to change the button color theme.
+Use the `theme` prop to change the button color theme.
 
-<div><ButtonVariantPreview></ButtonVariantPreview><div>
+<div><ButtonThemePreview></ButtonThemePreview><div>
 
 <br/>
 
@@ -43,7 +43,7 @@ Use the `size` prop to change the size of the button.
 
 #### State
 
-Use the `state` prop object to control that visual states from button.
+Use the `state` prop object to control the button state, the `disabled` prop allows you to change when the button can be activate.
 
 <div><ButtonStatePreview></ButtonStatePreview></div>
 
@@ -70,12 +70,12 @@ Use the `onClick` prop to trigger an action when the button is clicked.
 </thead>
 <tbody>
 <tr>
-<td>type</td>
+<td>variant</td>
 <td><LeHighlighter language="tsx" code="'filled' | 'outlined' | 'ghost'" style="soft" copy="'off'"></LeHighlighter></td>
 <td><LeHighlighter language="tsx" code="'filled'" style="soft" copy="'off'"></td>
 </tr>
 <tr>
-<td>variant</td>
+<td>theme</td>
 <td><LeHighlighter language="tsx" code="'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'default'" style="soft" copy="'off'"></LeHighlighter></td>
 <td><LeHighlighter language="tsx" code="'primary'" style="soft" copy="'off'"></td>
 </tr>

--- a/docs/src/pages/Select/SelectAttributes.tsx
+++ b/docs/src/pages/Select/SelectAttributes.tsx
@@ -257,6 +257,7 @@ const SelectMultiplePreview = () => {
 					multiple
 					onChange={handleValueChange}
 					valueSeparator=" + "
+					clickOptionHide={false}
 				/>
 			</div>
 			<LeHighlighter
@@ -282,6 +283,7 @@ const SelectMultiplePreview = () => {
 				multiple
 				onChange={handleValueChange}
 				valueSeparator=" + "
+				clickOptionHide={false}
 			/>
 		</>
 	);

--- a/src/components/Badge/Badge.model.ts
+++ b/src/components/Badge/Badge.model.ts
@@ -1,16 +1,16 @@
 import React from "react";
 
-type BadgeTypes = "dashed" | "ghost" | "outlined";
-type BadgeVariants = "primary" | "secondary" | "success" | "danger" | "warning" | "default";
+type BadgeVariants = "dashed" | "ghost" | "outlined";
+type BadgeThemes = "primary" | "secondary" | "success" | "danger" | "warning" | "default";
 type BadgeSizes = "small" | "medium" | "large";
 
 interface BadgeProps {
-	type?: BadgeTypes;
 	variant?: BadgeVariants;
-	children?: React.ReactNode;
+	theme?: BadgeThemes;
+	children?: React.ReactNode | string;
 	size?: BadgeSizes;
 	customClass?: string;
 	customStyles?: React.CSSProperties;
 }
 
-export { BadgeProps, BadgeTypes, BadgeSizes, BadgeVariants };
+export { BadgeProps, BadgeThemes, BadgeSizes, BadgeVariants };

--- a/src/components/Badge/Badge.spec.tsx
+++ b/src/components/Badge/Badge.spec.tsx
@@ -14,7 +14,7 @@ describe("Box component test", () => {
 	});
 
 	it("should render a Badge component with primary type", () => {
-		const { getByTestId } = render(<Badge variant="primary" />);
+		const { getByTestId } = render(<Badge theme="primary" />);
 
 		const box = getByTestId("leuxBadge");
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -3,8 +3,8 @@ import { BadgeProps } from "./Badge.model";
 import "./Badge.scss";
 
 const Badge = ({
-	type = "ghost",
-	variant = "default",
+	variant = "ghost",
+	theme = "default",
 	children,
 	size = "medium",
 	customStyles,
@@ -14,8 +14,8 @@ const Badge = ({
 		<span
 			className={
 				"le-badge" +
-				(type ? ` le-badge--${type}` : "") +
 				(variant ? ` le-badge--${variant}` : "") +
+				(theme ? ` le-badge--${theme}` : "") +
 				(size ? ` le-badge--${size}` : "") +
 				(customClass ? ` ${customClass}` : "")
 			}

--- a/src/components/Button/Button.model.ts
+++ b/src/components/Button/Button.model.ts
@@ -1,9 +1,8 @@
 import { MouseEvent } from "react";
 
-type ButtonVariants = "primary" | "secondary" | "success" | "danger" | "warning" | "default";
-
-type ButtonTypes = "filled" | "outlined" | "ghost";
-
+type ButtonThemes = "primary" | "secondary" | "success" | "danger" | "warning" | "default";
+type ButtonVariants = "filled" | "outlined" | "ghost";
+type ButtonTypes = "submit" | "reset" | "button";
 type ButtonSizes = "small" | "medium" | "large";
 
 interface ButtonState {
@@ -11,6 +10,7 @@ interface ButtonState {
 }
 
 interface ButtonProps {
+	theme?: ButtonThemes;
 	variant?: ButtonVariants;
 	type?: ButtonTypes;
 	size?: ButtonSizes;
@@ -21,4 +21,4 @@ interface ButtonProps {
 	customStyles?: React.CSSProperties;
 }
 
-export { ButtonProps, ButtonVariants, ButtonTypes, ButtonState, ButtonSizes };
+export { ButtonProps, ButtonVariants, ButtonThemes, ButtonState, ButtonSizes, ButtonTypes };

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -15,7 +15,7 @@ describe("Button component test", () => {
 
 	it("should render a Outlined Secondary Button component", () => {
 		const { getByTestId } = render(
-			<Button variant="secondary" type="outlined" size="large">
+			<Button theme="secondary" variant="outlined" size="large">
 				Secondary Button
 			</Button>
 		);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,9 +3,10 @@ import { ButtonProps } from "./Button.model";
 import "./Button.scss";
 
 const Button = ({
-	variant = "default",
+	theme = "default",
 	size = "medium",
-	type = "filled",
+	variant = "filled",
+	type = "button",
 	onClick,
 	state,
 	children,
@@ -21,13 +22,14 @@ const Button = ({
 	return (
 		<button
 			className={
-				`le-button le-button--${variant} le-button--${size} le-button--${type}` +
+				`le-button le-button--${variant} le-button--${size} le-button--${theme}` +
 				(state && state.disabled ? " le-button--disabled" : "") +
 				(customClass ? ` ${customClass}` : "")
 			}
+			type={type}
 			data-testid="leuxButton"
 			onClick={(event) => handleOnCLick(event)}
-			disabled={state?.disabled}
+			disabled={state && state.disabled}
 			style={customStyles}
 		>
 			{children}

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -175,10 +175,8 @@
 @keyframes fadeIn {
 	from {
 		opacity: 0;
-		height: 0;
 	}
 	to {
 		opacity: 1;
-		height: auto;
 	}
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -137,8 +137,6 @@ const Select = ({
 			document.addEventListener("mousedown", handleClickOutside);
 		}
 
-		document.addEventListener("mousedown", handleClickOutside);
-
 		if (!clickOutsideHide) {
 			document.removeEventListener("mousedown", handleClickOutside);
 		}


### PR DESCRIPTION
This PR changes rename some of the main attributes from Button and Badge component.

- old variant is commonly used as a theme style, but now is a design type style.
- old type was replacing the native component type attribute, now is the component type definition, e.g. button type as 'submit' | 'reset' | 'button'. 